### PR TITLE
Replace iat check with nbf check.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ IdTokenVerifier.prototype.verify = function (token, nonce, cb) {
   var aud = jwt.payload.aud;
   var iss = jwt.payload.iss;
   var exp = jwt.payload.exp;
-  var iat = jwt.payload.iat;
+  var nbf = jwt.payload.nbf;
   var tnonce = jwt.payload.nonce || null;
   /* eslint-enable vars-on-top */
 
@@ -63,7 +63,7 @@ IdTokenVerifier.prototype.verify = function (token, nonce, cb) {
     return cb(new error.TokenValidationError('Nonce does not match.'), false);
   }
 
-  var expirationError = this.verifyExpAndIat(exp, iat); // eslint-disable-line vars-on-top
+  var expirationError = this.verifyExpAndNbf(exp, nbf); // eslint-disable-line vars-on-top
 
   if (expirationError) {
     return cb(expirationError, false);
@@ -80,10 +80,10 @@ IdTokenVerifier.prototype.verify = function (token, nonce, cb) {
   });
 };
 
-IdTokenVerifier.prototype.verifyExpAndIat = function (exp, iat) {
+IdTokenVerifier.prototype.verifyExpAndNbf = function (exp, nbf) {
   var now = new Date();
   var expDate = new Date(0);
-  var iatDate = new Date(0);
+  var nbfDate = new Date(0);
 
   if (this.__disableExpirationCheck) {
     return null;
@@ -95,10 +95,12 @@ IdTokenVerifier.prototype.verifyExpAndIat = function (exp, iat) {
     return new error.TokenValidationError('Expired token.');
   }
 
-  iatDate.setUTCSeconds(iat - this.leeway);
-
-  if (now < iatDate) {
-    return new error.TokenValidationError('The token was issued in the future. ' +
+  if (typeof nbf === 'undefined') {
+    return null;
+  }
+  nbfDate.setUTCSeconds(nbf - this.leeway);
+  if (now < nbfDate) {
+    return new error.TokenValidationError('The token is not valid until later in the future. ' +
       'Please check your computed clock.');
   }
 

--- a/test/token-verification.test.js
+++ b/test/token-verification.test.js
@@ -190,15 +190,15 @@ describe('jwt-verification', function () {
     );
   });
 
-  it('should validate the iat claim', function (done) {
+  it('should validate the nbf claim', function (done) {
     helpers.assertTokenValidationError(
       {
         issuer: 'https://wptest.auth0.com/',
         audience: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
       },
       'asfd',
-      'The token was issued in the future. Please check your computed clock.',
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjk0ODI5NjkwMzEsImlhdCI6OTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
+      'The token is not valid until later in the future. Please check your computed clock.',
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJub25jZSI6ImFzZmQiLCJpYXQiOjE0OTczNjQyNzMsIm5iZiI6NDY1MzEyNDI3MywiZXhwIjo3ODA4ODg0MjczfQ.IWU4y_Q2jHOmOR50Kk64oYIa1scvRMxzOE7sly_R953eypSoHB1OEWROsG4-qsTStfaJ7c6LbxeCbzpiFMAXDr594vDXny2lb8W_mF8OoTBPxMMlSBisy60hcH_GJL864SNiijr4SEuPL5sAUAI4PL77FrMpVODZ_To9GwixkZ8ajN7E7CYwlK6xkUuq5PQOknNjc1KBFh5bwIuA5gRSi0ggp74pi3bR9MRGLxMvZx_7kxa6G2IeTcXYjBlDS8BnKpoW0d6vOK804DWA8OIYTTY8570FaOwxusxEK-D8LolA8v7JfYY2AvWkjXwxN9rtGlMjZrXiUMAk67eW8abGWw',
       done
     );
   });


### PR DESCRIPTION
This iat claim is for informational purposes only (and possibly to invalidate tokens that are too old, even with a valid exp date, as a client-only policy). Only the nbf claim should be checked.
https://tools.ietf.org/html/rfc7519#section-4.1.5
http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation