### PR TITLE
use base64-js methods instead of browser globals atob and btoa

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha test/**/*.test.js",
     "test:watch": "mocha --watch  -R min test/*.test.js",
     "test:coverage": "istanbul cover _mocha -R test/*.test.js",
-    "ci:test": "istanbul cover _mocha --report lcovonly -R test/**/* -- -R mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
+    "ci:test": "istanbul cover _mocha --report lcovonly -R test/** -- -R mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "ci:coverage": "codecov",
     "lint": "eslint ./src",
     "jsdoc:generate": "jsdoc --configure .jsdoc.json --verbose",

--- a/src/helpers/base64.js
+++ b/src/helpers/base64.js
@@ -39,9 +39,9 @@ function byteArrayToHex(raw) {
 }
 
 function encodeString(str) {
-  return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
+  return base64.fromByteArray(stringToByteArray(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
     return String.fromCharCode('0x' + p1);
-  }))
+  })))
   .replace(/\+/g, '-') // Convert '+' to '-'
   .replace(/\//g, '_'); // Convert '/' to '_';
 }
@@ -51,7 +51,7 @@ function decodeToString(str) {
     .replace(/\-/g, '+') // Convert '-' to '+'
     .replace(/_/g, '/'); // Convert '_' to '/'
 
-  return decodeURIComponent(atob(str).split('').map(function (c) {
+  return decodeURIComponent(byteArrayToString(base64.toByteArray(str)).split('').map(function (c) {
     return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
   }).join(''));
 }

--- a/test/base64.test.js
+++ b/test/base64.test.js
@@ -1,6 +1,4 @@
 var expect = require('expect.js');
-var atob = require('./helper/atob');
-var btoa = require('./helper/btoa');
 
 var base64 = require('../src/helpers/base64');
 
@@ -35,7 +33,7 @@ describe('helpers base64 url', function () {
 
     expect(base64.decodeToString('dGVzdA==')).to.eql('test');
     expect(base64.decodeToString('w6XDhsOYw6XDqcO8w6bDmA==')).to.eql('åÆØåéüæØ');
-    
+
   });
 
   it('padding', function () {

--- a/test/helper/atob.js
+++ b/test/helper/atob.js
@@ -1,5 +1,0 @@
-function atob(str) {
-  return new Buffer(str, 'base64').toString('binary');
-}
-
-module.exports = typeof window !== 'undefined' ? window.atob : global.atob = atob;

--- a/test/helper/btoa.js
+++ b/test/helper/btoa.js
@@ -1,5 +1,0 @@
-function btoa(str) {
-  return Buffer.from(str, 'binary').toString('base64');
-}
-
-module.exports = typeof window !== 'undefined' ? window.btoa : global.btoa = btoa;


### PR DESCRIPTION
I'm using this with Next.js which does server-side rendering of React. To support the Node context, I used the equivalent methods from the already-included `base64-js` package to eliminate the need for browser globals `atob` and `btoa`. (My API does more intense validation. This is a first line of defense to redirect to Auth0 as soon as possible)

ref #8 