### PR TITLE
Validate that response body is not empty

### DIFF
--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -26,6 +26,10 @@ function getJWKS(options, cb) {
         return cb(err);
       }
 
+      if (!data.body) {
+        return cb({error: true}, data);
+      }
+
       // eslint-disable-next-line no-plusplus
       for (a = 0; a < data.body.keys.length && matchingKey === null; a++) {
         key = data.body.keys[a];

--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -27,7 +27,7 @@ function getJWKS(options, cb) {
       }
 
       if (!data.body) {
-        return cb({error: true}, data);
+        return cb({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'}, data);
       }
 
       // eslint-disable-next-line no-plusplus

--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -27,7 +27,10 @@ function getJWKS(options, cb) {
       }
 
       if (!data.body) {
-        return cb({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'});
+        return cb({
+          error: 'invalid_request',
+          error_description: 'Could not fetch jwks.json information'
+        });
       }
 
       // eslint-disable-next-line no-plusplus

--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -27,7 +27,7 @@ function getJWKS(options, cb) {
       }
 
       if (!data.body) {
-        return cb({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'}, data);
+        return cb({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'});
       }
 
       // eslint-disable-next-line no-plusplus

--- a/test/jwks.test.js
+++ b/test/jwks.test.js
@@ -51,7 +51,7 @@ describe('jwks', function () {
         };
       });
       jwks.getJWKS({jwksURI: 'https://example.com/jwks.json'}, function(err, data) {
-        expect(err).to.be.eql({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'});
+        expect(err).to.be.eql({error: true});
         done();
       });
     });

--- a/test/jwks.test.js
+++ b/test/jwks.test.js
@@ -28,6 +28,20 @@ describe('jwks', function () {
         jwks.getJWKS({iss: 'https://iss.com/'});
       });
     });
+    it('returns error when data is empty', function (done) {
+      stub(request, 'get', function () {
+        return {
+          end: function(cb) {
+            cb(null, {});
+          }
+        };
+      });
+      jwks.getJWKS({jwksURI: 'https://example.com/jwks.json'}, function(err, data) {
+        expect(err).to.be.eql({error: true});
+        expect(data).to.be.eql({});
+        done();
+      });    
+    });
     it('returns error in the callback', function (done) {
       stub(request, 'get', function () {
         return {

--- a/test/jwks.test.js
+++ b/test/jwks.test.js
@@ -37,7 +37,7 @@ describe('jwks', function () {
         };
       });
       jwks.getJWKS({jwksURI: 'https://example.com/jwks.json'}, function(err, data) {
-        expect(err).to.be.eql({error: true});
+        expect(err).to.be.eql({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'});
         expect(data).to.be.eql({});
         done();
       });    

--- a/test/jwks.test.js
+++ b/test/jwks.test.js
@@ -38,7 +38,7 @@ describe('jwks', function () {
       });
       jwks.getJWKS({jwksURI: 'https://example.com/jwks.json'}, function(err, data) {
         expect(err).to.be.eql({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'});
-        expect(data).to.be.eql({});
+        expect(data).to.be(undefined);
         done();
       });    
     });

--- a/test/jwks.test.js
+++ b/test/jwks.test.js
@@ -51,7 +51,7 @@ describe('jwks', function () {
         };
       });
       jwks.getJWKS({jwksURI: 'https://example.com/jwks.json'}, function(err, data) {
-        expect(err).to.be.eql({error: true});
+        expect(err).to.be.eql({error: 'invalid_request', error_description: 'Could not fetch jwks.json information'});
         done();
       });
     });


### PR DESCRIPTION
Added a tiny verification for the data variable since some customers where seeing errors in which this variable was undefined.

ex.
The following line causes around 100 errors within 24 hours:
`for (a = 0; a < data.body.keys.length && matchingKey === null; a++) {`

The error message is:
`Cannot read property 'body' of undefined``

ZENDESK Ticket: https://auth0.zendesk.com/agent/tickets/43507