### PR TITLE
Add hint in README to use Map object for JWKS cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Parameters:
     + issuer: the issuer you trust to sign the tokens.
     + audience: the audience the token is issued for.
     + leeway: when there is a clock skew times between the signing and verifying servers. The leeway should not be biger than a minute.
-    + jwksCache: the verifier will try to fetch the JWKS from the `/.well-known/jwks.json` endpoint each time it verifies a token. You can provide a cache to store the keys and avoid repeated requests. For the contract, check [this example](https://github.com/auth0/jwt-js-rsa-verification/blob/master/src/helpers/dummy-cache.js).
+    + jwksCache: the verifier will try to fetch the JWKS from the `/.well-known/jwks.json` endpoint (or `jwksURI` if provided) each time it verifies a token. You can provide a cache to store the keys and avoid repeated requests. For the contract, check [this example](https://github.com/auth0/jwt-js-rsa-verification/blob/master/src/helpers/dummy-cache.js). Hint: for in-memory cache, an easy way is to just provide `new Map()`, which is a valid object for jwksCache. 
     + jwksURI: A valid, direct URI to fetch the JSON Web Key Set (JWKS). Defaults to `${id_token.iss}/.well-known/jwks.json`
 - callback
     + error: the validation error if any, null otherwise


### PR DESCRIPTION
As a first-time user of the library, and the one who is not very fluent in javascript, I was about to write my own implementation for essentially javascript's new Map() object, which can be easily plugged in into jwksCache paramater. 

I think this small description can save some not-fluent-in-js devs a couple or dozen of minutes when trying to make jwks cache work in this library. This PR is more like a feedback from me, decided to share. 

P. S. Another piece of feedback is that I use this library in Lambda@Edge in front of AWS Cloudfront, since the lambda there should be really really small (1MB zipped including node_modules). Thus I couldn't afford to use classic `jsonwebtoken` lib etc.