### PR TITLE
Add support for ES256 validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Return
 
 ## Support
 
-To make it as lightweight as posible, it only provides support for RS256 tokens. It can be easily extensible to other RS\* algorithms.
+To make it as lightweight as posible, it only provides support for RS256 and ES256 tokens. It can be easily extensible to other RS\* algorithms.
 
 ## Issue Reporting
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import * as base64 from './helpers/base64';
 import jwks from './helpers/jwks';
 import * as error from './helpers/error';
 import DummyCache from './helpers/dummy-cache';
-var supportedAlgs = ['RS256'];
+var supportedAlgs = ['RS256', 'ES256'];
 
 /**
  * Creates a new id_token verifier

--- a/test/token-verification.test.js
+++ b/test/token-verification.test.js
@@ -73,7 +73,7 @@ describe('jwt-verification', function() {
       {
         expectedAlg: 'HS256'
       },
-      'Algorithm HS256 is not supported. (Expected algs: [RS256])',
+      'Algorithm HS256 is not supported. (Expected algs: [RS256,ES256])',
       done
     );
   });
@@ -158,7 +158,7 @@ describe('jwt-verification', function() {
         audience: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt'
       },
       'asfd',
-      'Algorithm HS256 is not supported. (Expected algs: [RS256])',
+      'Algorithm HS256 is not supported. (Expected algs: [RS256,ES256])',
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
       done
     );


### PR DESCRIPTION
### Changes

This change allows using the idtoken-verifier library to be used also with ES256 algorithm.

### Testing

Unit tests updated and passing.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
