### PR TITLE
Use unfetch without requiring window at load time

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   "dependencies": {
     "base64-js": "^1.2.0",
     "crypto-js": "^3.1.9-1",
-    "es6-promise-polyfill": "^1.2.0",
-    "isomorphic-unfetch": "^3.0.0",
     "jsbn": "^0.1.0",
+    "promise-polyfill": "^8.1.3",
+    "unfetch": "^4.1.0",
     "url-join": "^1.1.0"
   },
   "keywords": [
@@ -67,6 +67,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.0.1",
     "moment": "^2.24.0",
+    "node-fetch": "^2.6.0",
     "nyc": "^13.3.0",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",

--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -1,7 +1,7 @@
 import urljoin from 'url-join';
 import * as base64 from './base64';
-import fetch from 'isomorphic-unfetch';
-import { Promise } from 'es6-promise-polyfill';
+import unfetch from 'unfetch';
+import Promise from 'promise-polyfill';
 
 export function process(jwks) {
   var modulus = base64.decodeToHEX(jwks.n);
@@ -23,9 +23,9 @@ function checkStatus(response) {
 }
 
 export function getJWKS(options, cb) {
+  const localFetch = typeof fetch == 'undefined' ? unfetch : fetch;
   var url = options.jwksURI || urljoin(options.iss, '.well-known', 'jwks.json');
-
-  return fetch(url)
+  return localFetch(url)
     .then(checkStatus)
     .then(function(data) {
       var matchingKey = null;

--- a/test/jwks.test.js
+++ b/test/jwks.test.js
@@ -7,7 +7,7 @@ describe('jwks', function() {
   beforeEach(() => {
     getProxy = s =>
       proxyquire('../src/helpers/jwks', {
-        ['isomorphic-unfetch']: s
+        ['unfetch']: s
       });
   });
   describe('getJWKS', function() {

--- a/test/token-verification.test.js
+++ b/test/token-verification.test.js
@@ -1,4 +1,5 @@
 import expect from 'expect.js';
+import nodeFetch from 'node-fetch';
 
 import CacheMock from './mock/cache-mock';
 import helpers from './helper/token-validation';
@@ -184,6 +185,12 @@ describe('jwt-verification', function() {
       });
     });
     describe('without stubing `getRsaVerifier`', () => {
+      beforeEach(() => {
+        global.fetch = nodeFetch;
+      });
+      afterEach(() => {
+        global.fetch = undefined;
+      });
       it('should fail with corrupt token', done => {
         helpers.assertTokenValidationError(
           {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,6 @@
 # yarn lockfile v1
 
 
-"@auth0/component-cdn-uploader@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@auth0/component-cdn-uploader/-/component-cdn-uploader-2.2.1.tgz#758443b38027ca1396fcb2476aa0e186eef1b7b5"
-  integrity sha512-IbB2BpKYGE3r5fJYDclpoFlKo/y7pohvbeEK6NACkbe/vWbnqrl9d/pRX5+vDWUJQfAgl8W8bDENPuXw1DS/zg==
-  dependencies:
-    "@auth0/s3" "^1.0.0"
-    chalk "^1.1.3"
-    meow "^3.7.0"
-    mime "^2.3.1"
-    request "^2.78.0"
-    rx "^4.1.0"
-    semver "^5.3.0"
-    walk "^2.3.9"
-
 "@auth0/component-cdn-uploader@auth0/component-cdn-uploader#v2.2.1":
   version "2.2.1"
   resolved "https://codeload.github.com/auth0/component-cdn-uploader/tar.gz/db92e90770ec4cd9d59f88db881cfea5c1a5d9af"
@@ -2075,11 +2061,6 @@ es6-error@^4.0.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-promise-polyfill@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz#f38925f23cb3e3e8ce6cda8ff774fcebbb090cde"
-  integrity sha1-84kl8jyz4+jObNqP93T867sJDN4=
-
 es6-promise@^4.0.3:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
@@ -3078,14 +3059,6 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-unfetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.0.0.tgz#de6d80abde487b17de2c400a7ef9e5ecc2efb362"
-  integrity sha512-V0tmJSYfkKokZ5mgl0cmfQMTb7MLHsBMngTkbLY0eXvKqiVRRoZP04Ly+KhKrJfKtzC9E6Pp15Jo+bwh7Vi2XQ==
-  dependencies:
-    node-fetch "^2.2.0"
-    unfetch "^4.0.0"
-
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -3866,6 +3839,11 @@ node-fetch@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -4966,6 +4944,11 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 promise.series@^0.2.0:
   version "0.2.0"
@@ -6192,7 +6175,7 @@ underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
-unfetch@^4.0.0:
+unfetch@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
   integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==


### PR DESCRIPTION
### Changes

`isomorphic-unfetch` tries to access `window` when it gets loadad. This breaks server rendered apps because there's no `window` when the server is rendering the application.
This PR uses `unfetch`, which only requires `window` when it actually makes the HTTP request, so we're safe to import in SSR apps.

### References

This was uncovered by https://github.com/auth0/auth0.js/issues/959. Thanks @timneutkens and @developit for all the help with this!

### Testing

Tests were changed to use `node-fetch` because `unfetch` uses browser-only APIs.
- [x] This change adds test coverage