### PR TITLE
[SDK-1166] Replaced promise-polyfill with es6-promise, applied globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "base64-js": "^1.3.0",
     "crypto-js": "^3.1.9-1",
+    "es6-promise": "^4.2.8",
     "jsbn": "^1.1.0",
-    "promise-polyfill": "^8.1.3",
     "unfetch": "^4.1.0",
     "url-join": "^4.0.1"
   },

--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -1,7 +1,9 @@
+import p from 'es6-promise';
+p.polyfill();
+
 import urljoin from 'url-join';
 import * as base64 from './base64';
 import unfetch from 'unfetch';
-import Promise from 'promise-polyfill';
 
 export function process(jwks) {
   var modulus = base64.decodeToHEX(jwks.n);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,7 +2306,7 @@ es6-error@^4.0.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-promise@^4.0.3:
+es6-promise@^4.0.3, es6-promise@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -5370,11 +5370,6 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
-
-promise-polyfill@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
-  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 promise.series@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Changes

This change introduces a new dependency to polyfill Promise, and the polyfill is now applied globally rather than just in the module that uses it.

The reason for applying globally is to fix those using IE11. While our own module was already polyfilled, we had also included `unfetch`, which requires a polyfill to be provided by the application. This PR provides that polyfill on behalf of our users.

The reason for changing the polyfill dependency is that `promise-polyfill` proved extremely difficult to test when importing `promise-polyfill/src/polyfill` (required to apply the polyfill globally). I could not seem to mock it using [`proxyquire`](https://www.npmjs.com/package/proxyquire). Instead, I'm using this new polyfill which is far easier to include and doesn't break the unit tests.

### Testing

Tested manually using Auth0.js and Browserstack in Windows 10/IE11

- [ ] This change adds test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
