### PR TITLE
[SDK-1266] Removed iat future value check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,18 @@
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: '70...100'
   status:
     patch:
       default:
         if_no_uploads: error
+        threshold: 50
     changes: true
     project:
       default:
         target: auto
         if_no_uploads: error
+        threshold: 2
   ignore:
     - src/helpers/rsa-verifier.js
     - scripts/

--- a/src/index.js
+++ b/src/index.js
@@ -283,22 +283,6 @@ IdTokenVerifier.prototype.verify = function(token, requestedNonce, cb) {
       );
     }
 
-    var iatTime = iat - _this.leeway;
-    var iatTimeDate = new Date(0);
-    iatTimeDate.setUTCSeconds(iatTime);
-
-    if (now < iatTimeDate) {
-      return cb(
-        new error.TokenValidationError(
-          'Issued At (iat) claim error in the ID token; current time "' +
-            now +
-            '" is before issued at time "' +
-            iatTimeDate +
-            '"'
-        )
-      );
-    }
-
     if (nbf && isNumber(nbf)) {
       var nbfTime = nbf - _this.leeway;
       var nbfTimeDate = new Date(0);

--- a/test/token-verification.test.js
+++ b/test/token-verification.test.js
@@ -454,28 +454,6 @@ describe('jwt-verification', function() {
             .catch(done);
         });
 
-        it('should validate the token issued at claim', done => {
-          const iat = nowSeconds() + 100;
-
-          const payload = Object.assign({}, DEFAULT_PAYLOAD, {
-            iat
-          });
-
-          createJWT(payload, DEFAULT_OPTIONS)
-            .then(token => {
-              helpers.assertTokenValidationError(
-                DEFAULT_CONFIG,
-                'asfd',
-                `Issued At (iat) claim error in the ID token; current time "${new Date()}" is before issued at time "${new Date(
-                  (iat - 60) * 1000
-                )}"`,
-                token,
-                done
-              );
-            })
-            .catch(done);
-        });
-
         it('should validate presence of auth_time when max_age was specified', done => {
           const config = Object.assign({}, DEFAULT_CONFIG, {
             maxAge: 1000


### PR DESCRIPTION
### Changes

This PR removes the future value check for the `issued-at` claim. Presence and type are still checked.

### Testing

Tests for the future value `iat` check have been removed.

- [ ] This change adds test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
