### PR TITLE
Fixed bug with keys not first in keybag

### DIFF
--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -40,16 +40,15 @@ export function getJWKS(options, cb) {
         if (key.kid === options.kid) {
           matchingKey = key;
         }
-
-        if (!matchingKey) {
-          return cb(
-            new Error(
-              'Could not find a public key for Key ID (kid) "' +
-                options.kid +
-                '"'
-            )
-          );
-        }
+      }
+      if (!matchingKey) {
+        return cb(
+          new Error(
+            'Could not find a public key for Key ID (kid) "' +
+              options.kid +
+              '"'
+          )
+        );
       }
       return cb(null, process(matchingKey));
     })


### PR DESCRIPTION
### Changes

While working on a PR for #100, realized this. Had to move the `if` statement outside of the for loop, or the `getJWKS` method would fail if the key isn't the first in the keybag.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
