### PR TITLE
issuer option can be a callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Initializes the verifier.
 Parameters:
 
 - configuration
-  - issuer: the issuer you trust to sign the tokens.
+  - issuer: the issuer you trust to sign the tokens, or a function that returns the value (the function takes one argument with the full payload of the token, decoded but not yet validated)
   - audience: the audience the token is issued for.
   - leeway: when there is a clock skew times between the signing and verifying servers. The leeway should not be bigger than five minutes.
   - jwksCache: the verifier will try to fetch the JWKS from the `/.well-known/jwks.json` endpoint (or `jwksURI` if provided) each time it verifies a token. You can provide a cache to store the keys and avoid repeated requests. For the contract, check [this example](https://github.com/auth0/jwt-js-rsa-verification/blob/master/src/helpers/dummy-cache.js). Hint: for in-memory cache, an easy way is to just provide `new Map()`, which is a valid object for jwksCache.

--- a/src/index.js
+++ b/src/index.js
@@ -160,11 +160,15 @@ IdTokenVerifier.prototype.verify = function(token, requestedNonce, cb) {
       );
     }
 
-    if ((typeof _this.issuer == 'function' && _this.issuer(jwt.payload) !== iss) || (typeof _this.issuer != 'function' && _this.issuer !== iss)) {
+    const expectIss =
+      typeof _this.issuer == 'function'
+        ? _this.issuer(jwt.payload)
+        : _this.issuer;
+    if (expectIss !== iss) {
       return cb(
         new error.TokenValidationError(
           'Issuer (iss) claim mismatch in the ID token, expected "' +
-            (typeof _this.issuer == 'function' ? _this.issuer(jwt.payload) : _this.issuer) +
+            expectIss +
             '", found "' +
             iss +
             '"'

--- a/test/helper/jwt.js
+++ b/test/helper/jwt.js
@@ -44,6 +44,9 @@ export const createJWT = (
   options = DEFAULT_OPTIONS
 ) => {
   return createCertificate().then(cert => {
+    if (typeof options.issuer == 'function') {
+      options.issuer = options.issuer(DEFAULT_PAYLOAD);
+    }
     return jwt.sign(payload, cert.serviceKey, {
       algorithm: 'RS256',
       keyid: 'QzE4N0ZBM0VDQzE2RUU0NzI1QzY1MzQ4QTk1MzAwMEI4RDgxNzE4Rg',

--- a/test/token-verification.test.js
+++ b/test/token-verification.test.js
@@ -193,6 +193,26 @@ describe('jwt-verification', function() {
             .catch(done);
         });
 
+        it('validates issuer as function', done => {
+          const options = Object.assign({}, DEFAULT_OPTIONS, {
+            issuer: function(payload) {
+              return '__ANOTHER_ISSUER__';
+            }
+          });
+
+          createJWT(DEFAULT_PAYLOAD, options)
+            .then(token => {
+              helpers.assertTokenValidationError(
+                DEFAULT_CONFIG,
+                'asfd',
+                `Issuer (iss) claim mismatch in the ID token, expected "__TEST_ISSUER__", found "__ANOTHER_ISSUER__"`,
+                token,
+                done
+              );
+            })
+            .catch(done);
+        });
+
         it('validates presence of subject in the token', done => {
           const { sub, ...payload } = DEFAULT_PAYLOAD;
 


### PR DESCRIPTION
### Changes

This is related to #100, even though the issue with version 2.0 was something different (see #101). This can still be a nice improvement in my opinion.

**The problem:** When using Azure AD in multi-tenant mode (when the authorization URL is `https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize`, for example; note the `organizations` part), the returned id_token contains an `iss` that contains the actual tenant ID (e.g. `https://login.microsoftonline.com/de366b7a-4861-4e17-b67b-8e3cdd4f2408/v2.0`). There is no way to know in advance what the tenant of the user that will sign in is, and instead we need to look at what's inside the `tid` claim in the id_token. This is a not-really-standard behavior, but I understand why it works this way.

**My previous workaround** (that works with 2.0 too, save for the bug in issue #100), was to decode the JWT before passing it to `idtoken-verifier`, get the `tid` and build the expected value for the `iss` claim:

```js
// Replace the tenant id in the issuer. We need to parse the jwt and look at the tid property
// We already know that the format is right
let tenant
try {
    const [, jwtPayloadB64] = jwt.split('.')
    const jwtPayloadStr = DecodeString(jwtPayloadB64)
    const jwtPayload = JSON.parse(jwtPayloadStr)
    tenant = jwtPayload && jwtPayload.tid
}
catch (e) {
    throw Error('JWT payload is invalid')
}
if (!tenant) {
    throw Error('Tenant ID missing in payload')
}

// Get the issuer
// AUTH_ISSUER looks like `https://login.microsoftonline.com/{tenant}/v2.0`
const issuer = process.env.AUTH_ISSUER.replace('{tenant}', tenant)

// Validate the token
const verifier = new IdTokenVerifier({
    jwksURI: process.env.JWKS_URL,
    issuer,
    audience: process.env.AUTH_CLIENT_ID
})
```

In short, it requires me to decode the JWT twice, and do a bunch of manual work.

**This PR** makes it possible to pass a function as the `issuer` option in the `IdTokenVerifier` constructor. The function receives the id_token's full payload as input, and returns a string with the expected value for the `iss` claim. With this PR, the code above becomes much cleaner:

```js
const verifier = new IdTokenVerifier({
    jwksURI: process.env.JWKS_URL,
    issuer: (payload) => {
        if (!payload || !payload.tid) {
            return process.env.AUTH_ISSUER
        }
        return process.env.AUTH_ISSUER.replace('{tenant}', payload.tid)
    },
    audience: process.env.AUTH_CLIENT_ID
})
```

PS: I haven't updated the documentation yet, but I'll do it if you show interest in this PR

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
