### PR TITLE
Asynchronous JWKS cache

### DIFF
--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -1,6 +1,3 @@
-import p from 'es6-promise';
-p.polyfill();
-
 import urljoin from 'url-join';
 import * as base64 from './base64';
 import unfetch from 'unfetch';
@@ -50,9 +47,17 @@ export function getJWKS(options, cb) {
           )
         );
       }
-      return cb(null, process(matchingKey));
+      if (cb) {
+        return cb(null, process(matchingKey));
+      } else {
+        return process(matchingKey);
+      }
     })
     .catch(function(e) {
-      cb(e);
+      if (cb) {
+        cb(e);
+      } else {
+        throw e;
+      }
     });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -355,8 +355,10 @@ IdTokenVerifier.prototype.getRsaVerifier = function(iss, kid, cb) {
           new Error('Empty keyInfo in response')
         );
       }
-      _this.jwksCache.set(cachekey, keyInfo);
-      return cb && cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
+      return _this.jwksCache.set(cachekey, keyInfo)
+        .then(function() {
+          return cb && cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
+        });
     })
     .catch(function(err) {
       return cb && cb(err);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+import p from 'es6-promise';
+p.polyfill();
+
 import sha256 from 'crypto-js/sha256';
 import cryptoBase64 from 'crypto-js/enc-base64';
 import cryptoHex from 'crypto-js/enc-hex';
@@ -332,25 +335,28 @@ IdTokenVerifier.prototype.getRsaVerifier = function(iss, kid, cb) {
   var _this = this;
   var cachekey = iss + kid;
 
-  if (!this.jwksCache.has(cachekey)) {
-    jwks.getJWKS(
-      {
-        jwksURI: this.jwksURI,
-        iss: iss,
-        kid: kid
-      },
-      function(err, keyInfo) {
-        if (err) {
-          return cb(err);
-        }
-        _this.jwksCache.set(cachekey, keyInfo);
-        return cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
+  Promise.resolve(this.jwksCache.has(cachekey))
+    .then(function(hasKey){
+      if (!hasKey) {
+        return jwks.getJWKS(
+          {
+            jwksURI: _this.jwksURI,
+            iss: iss,
+            kid: kid
+          }
+        );
+      } else {
+        return _this.jwksCache.get(cachekey);
       }
-    );
-  } else {
-    var keyInfo = this.jwksCache.get(cachekey); // eslint-disable-line vars-on-top
-    cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
-  }
+    })
+    .then(function(keyInfo) {
+      _this.jwksCache.set(cachekey, keyInfo);
+      return cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
+    })
+    .catch(function(err) {
+      console.log(err, cb);
+      return cb(err);
+    });
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -351,17 +351,15 @@ IdTokenVerifier.prototype.getRsaVerifier = function(iss, kid, cb) {
     })
     .then(function(keyInfo) {
       if (!keyInfo || !keyInfo.modulus || !keyInfo.exp) {
-        return cb && cb(
-          new Error('Empty keyInfo in response')
-        );
+        throw new Error('Empty keyInfo in response')
       }
-      return _this.jwksCache.set(cachekey, keyInfo)
+      return Promise.resolve(_this.jwksCache.set(cachekey, keyInfo))
         .then(function() {
-          return cb && cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
+          cb && cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
         });
     })
     .catch(function(err) {
-      return cb && cb(err);
+      cb && cb(err);
     });
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -350,12 +350,16 @@ IdTokenVerifier.prototype.getRsaVerifier = function(iss, kid, cb) {
       }
     })
     .then(function(keyInfo) {
+      if (!keyInfo || !keyInfo.modulus || !keyInfo.exp) {
+        return cb && cb(
+          new Error('Empty keyInfo in response')
+        );
+      }
       _this.jwksCache.set(cachekey, keyInfo);
-      return cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
+      return cb && cb(null, new RSAVerifier(keyInfo.modulus, keyInfo.exp));
     })
     .catch(function(err) {
-      console.log(err, cb);
-      return cb(err);
+      return cb && cb(err);
     });
 };
 

--- a/test/mock/async-cache.js
+++ b/test/mock/async-cache.js
@@ -1,0 +1,24 @@
+export function TimeoutPromise(ms) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function AsyncCache(cache) {
+  this.cache = cache;
+}
+
+AsyncCache.prototype.get = function(key) {
+  return TimeoutPromise(10)
+    .then(this.cache.get(key));
+};
+
+AsyncCache.prototype.has = function(key) {
+  return TimeoutPromise(10)
+    .then(this.cache.has(key));
+};
+
+AsyncCache.prototype.set = function(key, value) {
+  return TimeoutPromise(10)
+    .then(this.cache.set(key));
+};

--- a/test/token-verification.test.js
+++ b/test/token-verification.test.js
@@ -616,7 +616,7 @@ describe('jwt-verification', function() {
       var err = 'error';
 
       sinon.stub(mockJwks, 'getJWKS').callsFake(function(obj, cb) {
-        cb(err);
+        return Promise.reject(err);
       });
 
       var revert = IdTokenVerifier.__set__({ jwks: mockJwks });


### PR DESCRIPTION
### Changes

This PR includes the ability to support asynchronous JWKS caches. These are classes in which the `has`, `get`, and `set` methods (see the `DummyCache` contract) return a Promise. This is backwards-compatible, so the methods can either return a Promise (or, more correctly, a then-able object), or synchronously return a value.

This allows caching JWKS keys that are not synchronously available. For example, it could be possible for the application to request the keys and cache them (maybe even using a service worker).

### Testing

Tests have been updated and are passing. Because the patch is backwards-compatible, tests that were not stubbing methods did not require any change. A couple of tests that were stubbing methods required minor tweaks. Additionally, a test has been added to use an asynchronous cache.

- [X] This change adds test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
