### PR TITLE
Fixed: exception when key not found in JWKS

### DIFF
--- a/src/helpers/jwks.js
+++ b/src/helpers/jwks.js
@@ -39,12 +39,8 @@ export function getJWKS(options, cb) {
         }
       }
       if (!matchingKey) {
-        return cb(
-          new Error(
-            'Could not find a public key for Key ID (kid) "' +
-              options.kid +
-              '"'
-          )
+        throw new Error(
+          'Could not find a public key for Key ID (kid) "' + options.kid + '"'
         );
       }
       if (cb) {


### PR DESCRIPTION
### Changes

This PR fixes an exception thrown by the library when requesting a key with a kid not present in the JWKS. This happens when the `getJWKS` method is invoked asynchronously (without a callback).

In all honesty, this bug was my fault from the beginning as I introduced it with #107 😞 

### Testing

I have added two more unit tests specifically testing `getJWKS` when returning promises. Hopefully this will make it so similar bugs won't happen again in the future.

- [X] This change adds test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
