### PR TITLE
Pin crypto-js to 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3923,9 +3923,9 @@
       "dev": true
     },
     "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
     },
     "css-color-names": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "base64-js": "^1.3.0",
-    "crypto-js": "^4.0.0",
+    "crypto-js": "3.3.0",
     "es6-promise": "^4.2.8",
     "jsbn": "^1.1.0",
     "unfetch": "^4.1.0",


### PR DESCRIPTION
### Changes

This PR pins [crypto-js](https://github.com/brix/crypto-js) to 3.3.0. The
current version requires a native implemenation of `crypto`, which breaks
dependents further up the chain who do not have an immediate resolution
available.

### References

https://github.com/brix/crypto-js/issues/262

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
