### PR TITLE
Fix postbump script

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -2,5 +2,5 @@
     "files": {
         "src/telemetry.js": []
     },
-    "postbump": "node scripts/jsdocs.js && npm run print-bundle-size"
+    "postbump": "npm run build && node scripts/jsdocs.js"
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   ],
   "scripts": {
     "start": "gulp dev",
+    "prebuild": "rm -rf build",
     "build": "microbundle --target web --external none",
-    "clean": "rm -rf build",
+    "postbuild": "node scripts/print-bundle-size",
     "test": "cross-env NODE_ENV=test mocha --require @babel/register test/**/*.test.js --exit",
     "test:watch": "cross-env NODE_ENV=test mocha --require @babel/register --watch --reporter min test/*.test.js",
     "test:coverage": "nyc npm run test",
@@ -24,9 +25,8 @@
     "ci:test": "nyc npm run test -- --forbid-only --reporter mocha-junit-reporter",
     "ci:coverage": "codecov",
     "jsdoc:generate": "jsdoc --configure .jsdoc.json --verbose",
-    "prepack": "npm run clean && npm run build",
+    "prepack": "npm run build",
     "upload": "ccu build",
-    "print-bundle-size": "node scripts/print-bundle-size",
     "precommit": "pretty-quick --staged"
   },
   "author": "Auth0",


### PR DESCRIPTION
### Changes

Running the release CLI was failing on this repo because the library had to be built before running `node scripts/print-bundle-size`:

<img width="685" alt="Screen Shot 2021-09-09 at 17 20 35" src="https://user-images.githubusercontent.com/5055789/132757029-60ca2da8-30b6-4f41-bb11-0f137700b488.png">

This PR updates the `package.json` scripts such as that:
- The "clean" script (`rm -rf build`) runs before the build
- The "print-bundle-size" (`node scripts/print-bundle-size`) script runs after the build

And the `.shiprc`postbump script was updated to run `npm run build && node scripts/jsdocs.js`:

<img width="524" alt="Screen Shot 2021-09-09 at 17 16 06" src="https://user-images.githubusercontent.com/5055789/132757754-94afd4cb-4928-4857-9b8a-483b5f5f9fd3.png">

### Testing

- [ ] This change adds test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors