### PR TITLE
fix: restore missing badges removed by DeepWiki PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A lightweight library to decode and verify RSA ID tokens meant for the browser.
 
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/idtoken-verifier)
+[![Build Status][circleci-image]][circleci-url] [![NPM version][npm-image]][npm-url] [![Coverage][codecov-image]][codecov-url] [![License][license-image]][license-url] [![Downloads][downloads-image]][downloads-url] [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/idtoken-verifier)
 
 :books: [Documentation](#documentation) - :rocket: [Getting Started](#getting-started) - :computer: [API Reference](#api-reference) - :speech_balloon: [Feedback](#feedback)
 


### PR DESCRIPTION
### Changes

- Restores 5 badges (Build Status, NPM version, Coverage, License, Downloads) that were accidentally removed by #194
- Adds the DeepWiki badge alongside the restored badges
- All badges rendered on a single line to match repo convention

### References

- #194 (introduced the regression)

### Testing

Visually verify badges render inline on the repo's main page after merge.

- [ ] This change adds test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors